### PR TITLE
Support a content or source argument for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ in order to disable plugin use `ensure => absent`:
   }
 ```
 
+New since version 0.2.x (XXX: TODO)
+
+```puppet
+  hindsight::plugin {'debug':
+    filename => '',
+    target   => output/debug',
+    content  => template('path/to/template.erb');
+  }
+  # or
+  hindsight::plugin {'debug':
+    filename => '',
+    target   => output/debug',
+    source   => 'puppet:///fubarmodule/debug.cfg';
+  }
+```
+
 ## Service pre-start commands
 
 Before starting Hindsight service custom commands can be provided:

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -29,21 +29,25 @@ define hindsight::plugin (
       }
     }
 
-    # if one gives a CONTENT or SOURCE arg, take that
-    if $content != undef or $source != undef {
-      concat::fragment { $title:
+    concat::fragment { $title:
         target  => $path,
-        content => $content,
-        source  => $source,
-        order   => $order;
-      }
-    } else {
-      concat::fragment { $title:
-        target  => $path,
-        content =>  template('hindsight/plugin.cfg.erb'),
-        order   => $order;
-      }
+        order   => $order,
     }
+
+    if $content {
+        Concat::Fragment<| title == $title |> {
+            content => $content,
+        }
+    } elsif $source {
+        Concat::Fragment<| title == $title |> {
+            source => $source,
+        }
+    } else {
+        Concat::Fragment<| title == $title |> {
+            content =>  template('hindsight/plugin.cfg.erb'),
+        }
+    }
+
     if $manage_service {
       Concat::Fragment<| title == $title |> {
         notify => Service[$service_name]

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -10,6 +10,8 @@ define hindsight::plugin (
   $manage_service = $::hindsight::manage_service,
   $service_name   = $::hindsight::service_name,
   $run_dir        = $::hindsight::run_dir,
+  $content        = undef,
+  $source         = undef,
 ){
   $path = "${run_dir}/${target}.cfg"
 
@@ -27,10 +29,20 @@ define hindsight::plugin (
       }
     }
 
-    concat::fragment { $title:
-      target  => $path,
-      content =>  template('hindsight/plugin.cfg.erb'),
-      order   => $order,
+    # if one gives a CONTENT or SOURCE arg, take that
+    if defined('$content') or defined('$source') {
+      concat::fragment { $title:
+        target  => $path,
+        content => $content,
+        source  => $source,
+        order   => $order;
+      }
+    } else {
+      concat::fragment { $title:
+        target  => $path,
+        content =>  template('hindsight/plugin.cfg.erb'),
+        order   => $order;
+      }
     }
     if $manage_service {
       Concat::Fragment<| title == $title |> {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -30,7 +30,7 @@ define hindsight::plugin (
     }
 
     # if one gives a CONTENT or SOURCE arg, take that
-    if defined('$content') or defined('$source') {
+    if $content != undef or $source != undef {
       concat::fragment { $title:
         target  => $path,
         content => $content,


### PR DESCRIPTION
This would be a possible solution to #1. As an operator I really don't want to fight with puppets DSL to express myself in LUA. So it is opinionated.

It does open the way to add a few templates to this repo that tackle typical use cases with a specialized template, like "Tail this and this file, decode with such and such decoder", or "ship to elasticsearch", or "prune inputs and/or analysis".

Thoughts?